### PR TITLE
Fix Fernet docs (changed key size to 256 bits)

### DIFF
--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -155,7 +155,7 @@ Specifically it uses:
 
 * :class:`~cryptography.hazmat.primitives.ciphers.algorithms.AES` in
   :class:`~cryptography.hazmat.primitives.ciphers.modes.CBC` mode with a
-  128-bit key for encryption; using
+  256-bit key for encryption; using
   :class:`~cryptography.hazmat.primitives.padding.PKCS7` padding.
 * :class:`~cryptography.hazmat.primitives.hmac.HMAC` using
   :class:`~cryptography.hazmat.primitives.hashes.SHA256` for authentication.


### PR DESCRIPTION
Hi, looking at the source code of the Fernet cipher implementation i saw that it uses a 32 bytes (256 bits) key size. In the documentation it says its size it is of 128 bits so if i'm right it should be fixed.
